### PR TITLE
Fix typo and broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A template for a [Github Pages](https://pages.github.com) hosted syllabus.
 
 - See the [live site](https://jan-martinek.github.io/gh-syllabus/) generated from this repo.
-- See the code in the [`master` branch](https://github.com/jan-martinek/gh-syllabus/tree/gh-pages).
+- See the code in the [`master` branch](https://github.com/jan-martinek/gh-syllabus/tree/master).
 - Fork/clone this repository and make your own course syllabus on Github Pages.
 
 ## Syllabi based on this template

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ A template for a [Github Pages](https://pages.github.com) hosted syllabus.
 
 
 
-Licensed under MIT License.
+Licensed under [MIT License](./LICENSE).

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ menuPosition: 1
 	- Edit the `something.md` files in the root folder and unit descriptions in `_syllabus/`.
 
 
-## Why to enroll?
+## Why enroll?
 
 - There's a good reason.
 - And another one.


### PR DESCRIPTION
This PR makes two superficial changes, primarily fixing a typo/grammatical error in the index of the sample syllabus and additionally adding a link in the readme to the MIT license. It also fixes a broken link to the master branch in the readme.